### PR TITLE
essential ではなく recommended を使うようにする

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": ["numb", "plugin:vue/essential"]
+  "extends": ["numb", "plugin:vue/recommended"]
 }


### PR DESCRIPTION
より多くのルールを追加する。

これにより、ESLintの設定に以下の差分が発生する。
```diff
     "vue/valid-v-once": "error",
     "vue/valid-v-pre": "error",
     "vue/valid-v-show": "error",
-    "vue/valid-v-text": "error"
+    "vue/valid-v-text": "error",
+    "vue/attribute-hyphenation": "error",
+    "vue/html-end-tags": "error",
+    "vue/html-indent": "error",
+    "vue/html-self-closing": "error",
+    "vue/max-attributes-per-line": "error",
+    "vue/mustache-interpolation-spacing": "error",
+    "vue/name-property-casing": "error",
+    "vue/no-multi-spaces": "error",
+    "vue/require-default-prop": "error",
+    "vue/require-prop-types": "error",
+    "vue/v-bind-style": "error",
+    "vue/v-on-style": "error",
+    "vue/attributes-order": "error",
+    "vue/html-quotes": "error",
+    "vue/no-confusing-v-for-v-if": "error",
+    "vue/order-in-components": "error",
+    "vue/this-in-template": "error"
   },
```